### PR TITLE
feat(core): Add optional prefix for commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ Type **y** to accept and commit the changes, or **n** to abort.
  ...
 ```
 
+## Configuration
+
+Optional prefix for the commit message can be set with the `--prefix` flag:
+
+```sh
+cmt --prefix "TASK-1234"
+```
+
+or
+
+```sh
+cmt -p "TASK-1234"
+```
+
+Resulting commit message:
+
+```sh
+💬 Message:
+TASK-1234 feat(core): Add user authentication
+
+Implemented JWT-based authentication for API endpoints. Users can now log in and receive a token for subsequent requests.
+
+Accept? (y/n):
+```
+
 ## License
 
 Distributed under the MIT License. See `LICENSE` for more information.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -16,10 +17,12 @@ import (
 func main() {
 	f := flags.Parse()
 	if f.Version {
-		f.PrintVersion()
+		f.PrintVersion(os.Stdout)
 		return
-	} else if f.Help {
-		f.PrintHelp()
+	}
+
+	if f.Help {
+		f.PrintHelp(os.Stdout)
 		return
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,6 +47,10 @@ func main() {
 		return
 	}
 
+	if f.Prefix != "" {
+		message = fmt.Sprintf("%s %s", f.Prefix, message)
+	}
+
 	fmt.Printf("💬 Message: %s", message)
 	fmt.Print("\n\nAccept? (y/n): ")
 

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -11,12 +11,14 @@ const VERSION = "0.1.0"
 type Flags struct {
 	Version bool
 	Help    bool
+	Prefix  string
 }
 
 func Parse() Flags {
 	f := Flags{}
 	flag.BoolVar(&f.Version, "version", false, "Print version")
 	flag.BoolVar(&f.Help, "help", false, "Print help")
+	flag.StringVar(&f.Prefix, "prefix", "", "Optional prefix for commit message\nexample: --prefix TASK-1234")
 	flag.Parse()
 	return f
 }

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -3,6 +3,7 @@ package flags
 import (
 	"flag"
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -23,15 +24,13 @@ func Parse() Flags {
 	return f
 }
 
-func (f Flags) PrintVersion() {
-	fmt.Printf("cmt %s\n", VERSION)
+func (f Flags) PrintVersion(w io.Writer) {
+	fmt.Fprintf(w, "cmt %s\n", VERSION)
 }
 
-func (f Flags) PrintHelp() {
-	_, err := fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options]\n\n", os.Args[0])
-	fmt.Println("These are common cmt commands:")
-	if err != nil {
-		return
-	}
+func (f Flags) PrintHelp(w io.Writer) {
+	fmt.Fprintf(w, "Usage: %s [options]\n\n", os.Args[0])
+	fmt.Fprintln(w, "These are common cmt commands:")
+	flag.CommandLine.SetOutput(w)
 	flag.PrintDefaults()
 }

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -24,6 +24,7 @@ func TestParse(t *testing.T) {
 			expected: Flags{
 				Version: false,
 				Help:    false,
+				Prefix:  "",
 			},
 		},
 		{
@@ -32,6 +33,7 @@ func TestParse(t *testing.T) {
 			expected: Flags{
 				Version: true,
 				Help:    false,
+				Prefix:  "",
 			},
 		},
 		{
@@ -40,6 +42,16 @@ func TestParse(t *testing.T) {
 			expected: Flags{
 				Version: false,
 				Help:    true,
+				Prefix:  "",
+			},
+		},
+		{
+			name: "Prefix flag",
+			args: []string{"cmd", "-prefix", "TASK-1234"},
+			expected: Flags{
+				Version: false,
+				Help:    false,
+				Prefix:  "TASK-1234",
 			},
 		},
 		{
@@ -48,6 +60,7 @@ func TestParse(t *testing.T) {
 			expected: Flags{
 				Version: true,
 				Help:    true,
+				Prefix:  "",
 			},
 		},
 		{
@@ -56,6 +69,7 @@ func TestParse(t *testing.T) {
 			expected: Flags{
 				Version: false,
 				Help:    false,
+				Prefix:  "",
 			},
 		},
 	}

--- a/internal/flags/flags_test.go
+++ b/internal/flags/flags_test.go
@@ -55,7 +55,7 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
-			name: "Both flags",
+			name: "Two flags",
 			args: []string{"cmd", "-version", "-help"},
 			expected: Flags{
 				Version: true,
@@ -82,6 +82,58 @@ func TestParse(t *testing.T) {
 
 			f := Parse()
 			assert.Equal(t, tt.expected, f)
+		})
+	}
+}
+
+func TestPrintVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "Print version",
+			args:     []string{"cmd", "--version"},
+			expected: "cmt 0.1.0\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			f := Flags{}
+			f.PrintVersion(&buf)
+
+			result := buf.String()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPrintHelp(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "Print help",
+			args:     []string{"cmd", "--help"},
+			expected: "These are common cmt commands:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			f := Flags{}
+			f.PrintHelp(&buf)
+
+			result := buf.String()
+			assert.Contains(t, result, tt.expected)
 		})
 	}
 }


### PR DESCRIPTION
Introduced a `--prefix` flag to allow users to set an optional prefix for the commit message. 
The prefix can be specified using either `--prefix <prefix>` or `-p <prefix>` when invoking the command. 