### PR TITLE
chore(github/workflows): Add Golang CI linter to checks workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23.1'
@@ -22,3 +20,15 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+  linter:
+    name: Golang CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.1'
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -13,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23.1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,11 @@ func main() {
 	fmt.Print("\n\nAccept? (y/n): ")
 
 	var response string
-	fmt.Scanln(&response)
+	_, err = fmt.Scanln(&response)
+	if err != nil {
+		log.Fatalf("❌ Error reading response: %s\n", err)
+		return
+	}
 	response = strings.TrimSpace(strings.ToLower(response))
 
 	if response == "y" {


### PR DESCRIPTION
Adds a new job to the GitHub Actions workflow for Golang CI, which includes steps for checking out the code, setting up Go version 1.23.1, and running the GolangCI linter.