### PR TITLE
chore(.github): Add Dependabot configuration file for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    assignees:
+      - "tab"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly
+    assignees:
+      - "tab"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This commit introduces a new Dependabot configuration file to manage version updates for GitHub Actions and Go modules. The updates are scheduled to occur monthly, with a limit of 10 open pull requests at a time.