### PR TITLE
chore(config): Use gpt-4.1-nano as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ api:
 editor: vim       # Editor to use for interactive editing
 
 model:
-  name: gpt-4o-mini  # OpenAI model to use
+  name: gpt-4.1-nano # OpenAI model to use
   max_tokens: 500    # Maximum tokens for the model response
   temperature: 0.7   # Controls randomness of the model output
 

--- a/cmt.yaml
+++ b/cmt.yaml
@@ -5,7 +5,7 @@ api:
 editor: vim
 
 model:
-  name: gpt-4o-mini
+  name: gpt-4.1-nano
   max_tokens: 500
   temperature: 0.7
 

--- a/internal/app/gpt/gpt.go
+++ b/internal/app/gpt/gpt.go
@@ -125,7 +125,7 @@ func (g *client) FetchCommitMessage(ctx context.Context, diff string) (string, e
 	g.log.Debug().Msg("Fetching commit message from GPT")
 	content, err := g.fetch(ctx, messages)
 	if err != nil {
-		g.log.Error().Err(err).Msg("Failed to fetch commit message")
+		g.log.Debug().Err(err).Msg("Failed to fetch commit message")
 		return "", err
 	}
 
@@ -180,7 +180,7 @@ func (g *client) fetch(ctx context.Context, messages []Message) (string, error) 
 	}
 
 	if resp.IsError() {
-		g.log.Error().
+		g.log.Debug().
 			Int("status_code", resp.StatusCode()).
 			Str("response", resp.String()).
 			Msg("API returned error")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	DefaultTimeout     = 60 * time.Second
-	DefaultModelName   = "gpt-4o-mini"
+	DefaultModelName   = "gpt-4.1-nano"
 	DefaultMaxTokens   = 500
 	DefaultTemperature = 0.7
 	DefaultRetryCount  = 3


### PR DESCRIPTION
- Use gpt-4.1-nano as default model
- Change logging level from error to debug